### PR TITLE
twitch example: Correct LUA includes

### DIFF
--- a/servers/twitch_fragments/outcomes.lua
+++ b/servers/twitch_fragments/outcomes.lua
@@ -1,4 +1,6 @@
+dofile("data/scripts/lib/utilities.lua")
 dofile("data/scripts/perks/perk.lua")
+dofile("data/scripts/perks/perk_list.lua")
 
 local function insert_constant(outcome)
   table.insert(outcome_generators, function()


### PR DESCRIPTION
The `outcomes.lua` file lacks a few includes for the current version of Noita causing LUA errors and thereby the perk list to be understaffed or even empty.